### PR TITLE
Added dependencies in pom.xml to reformat Java files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@ limitations under the License.
 		<artifactId>google-cloud-translate</artifactId>
 		<version>1.55.0</version>
 	</dependency>
+
+	<dependency>
+		<groupId>com.google.googlejavaformat</groupId>
+		<artifactId>google-java-format</artifactId>
+		<version>1.6</version>
+	</dependency>
+
   </dependencies>
 
   <build>
@@ -80,6 +87,22 @@ limitations under the License.
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
         <version>1.9.59</version>
+      </plugin>
+
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.8</version>
+        <configuration>
+        	<displayLimit>10</displayLimit>
+        </configuration>
+        <executions>
+          <execution>
+          	<goals>
+       			<goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Whenever you run the command `mvn appengine:devserver` or any related command which involves rebuilding source, maven will reformat files to match Google's Java style guidelines